### PR TITLE
Added Content-Type to blob upload

### DIFF
--- a/ReleaseBadge/GenerateBadge/GenerateBadge.cs
+++ b/ReleaseBadge/GenerateBadge/GenerateBadge.cs
@@ -60,7 +60,7 @@ namespace ReleaseBadge
 
             log.Info($"going to generate badge with name {badgeFileName}");
 
-            var blobUri = await WriteBadgeToStorage(eventHelper, parameterHelper, binder, badgeFileName);
+            var blobUri = await WriteBadgeToStorage(eventHelper, parameterHelper, binder, badgeFileName, parameterHelper.GetFileType());
 
             log.Info($"badge stored on {blobUri}");
 
@@ -94,7 +94,7 @@ namespace ReleaseBadge
         /// <param name="binder"></param>
         /// <param name="badgeFileName"></param>
         /// <returns>the uri of the blob the badge was written to</returns>
-        private static async Task<string> WriteBadgeToStorage(DeploymentCompletedEventHelper helper, ConfigurationHelper configurationHelper, Binder binder, string badgeFileName)
+        private static async Task<string> WriteBadgeToStorage(DeploymentCompletedEventHelper helper, ConfigurationHelper configurationHelper, Binder binder, string badgeFileName, string contentType)
         {
             var generator = new ShieldsIOBadgeGenerator();
 
@@ -117,6 +117,7 @@ namespace ReleaseBadge
             CloudBlockBlob cloudBlob = await binder.BindAsync<CloudBlockBlob>(attributes);
 
             cloudBlob.Properties.CacheControl = $"public, max-age={maxAge}";
+            cloudBlob.Properties.ContentType = (contentType == "svg") ? $"image/{contentType}+xml" : $"image/{contentType}";
 
             await cloudBlob.UploadFromByteArrayAsync(badgeContent, 0, badgeContent.Length);
 


### PR DESCRIPTION
Tiago,
Great Work! For this to be used in GitHub, when you place the final badge image
 (with a blob storage url), GitHub will use [open-source project Camo](https://github.com/atmos/camo). 
This images only support specific content-types ([the list of types supported by Camo](https://github.com/atmos/camo/blob/master/mime-types.json)). When you upload to Blob Storage you probably get application/octet-stream content-type and it won't work.

Updated code to specify the content-type for the allowed types (png, gif, svg).

Used it the Outsystems project! Thanks
